### PR TITLE
add documentation for checkout popup via widget and Tipser-elements

### DIFF
--- a/source/includes/_tipser-elements.md
+++ b/source/includes/_tipser-elements.md
@@ -40,12 +40,28 @@ Start the application
 `npm start`
 
 ### Example inserting elements in your site
-You can combine Tipser Elements with your own application
+You can combine Tipser Elements with your own application:
 
-- `TipserElementsProvider` entry point to Tipser Elements (creating a context for other Elements) with the `tipserElementsConfig` as props.
-- `TipserElement` is a generic Element that can render any Contentful content that's fed as a prop to the element.
-- `TipserProduct` is the Element that renders the product given the Tipser product ID as the prop.
-- `CartIcon` is the Element that displays the number of items in your cart and gives the user a way to open the checkout dialog.
+#### `TipserElementsProvider` 
+Entry point to Tipser Elements (creating a context for other Elements);
+
+prop name  | description | type  | required | default value 
+-----------|-------------|-------|----------|--------------
+posId | id of Point of sale | string | true | 
+config | configuration object | {} | false   | {}
+defaultAddedToCartPopup | controls whether default Added To Cart Popup is displayed | boolean | false | true
+ 
+#### `TipserElement` 
+Generic Element that can render any Contentful content that's fed as a prop to the element.
+
+#### `TipserProduct` 
+Element that renders the product given the Tipser product ID as the prop.
+
+#### `CartIcon` 
+Element that displays the number of items in your cart and gives the user a way to open the checkout dialog.
+
+
+#### Example of above components used together:
 
 ```js
 import React from 'react';
@@ -54,7 +70,7 @@ import { TipserElement, TipserProduct, CartIcon, TipserElementsProvider } from '
 
 const tipserElementsConfig = {
     lang: 'en',
-    primaryColor: 'blue'
+    primaryColor: 'blue',    
 };
 
 ReactDOM.render(
@@ -76,8 +92,6 @@ ReactDOM.render(
     document.getElementById('root'));
 ```
 > root is the id of the HTML element where the Tipser element goes 
-
-## Available components
 
 ### Content components
 Content components are the building blocks of Tipser Elements. Any components need to be a descendant of **TipserElementsProvider** component. Container components such as **Grid** may contain other components. 

--- a/source/includes/_tipser-elements.md
+++ b/source/includes/_tipser-elements.md
@@ -48,8 +48,7 @@ Entry point to Tipser Elements (creating a context for other Elements);
 prop name  | description | type  | required | default value 
 -----------|-------------|-------|----------|--------------
 posId | id of Point of sale | string | true | 
-config | configuration object | {} | false   | {}
-defaultAddedToCartPopup | controls whether default Added To Cart Popup is displayed | boolean | false | true
+config | configuration object (see [definition here](#all-configuration-options-of-tipser-elements)) | {} | false   | {}
  
 #### `TipserElement` 
 Generic Element that can render any Contentful content that's fed as a prop to the element.
@@ -91,7 +90,17 @@ ReactDOM.render(
     </TipserElementsProvider>, 
     document.getElementById('root'));
 ```
-> root is the id of the HTML element where the Tipser element goes 
+> root is the id of the HTML element where the Tipser element goes
+
+### All configuration options of Tipser Elements
+
+Configuration is an object, that should be inserted into `TipserElementsProvider` as `config` prop.
+
+All properties are optional:
+
+property name | description |type | default value
+--------------|-------------|-----|---------------
+defaultAddedToCartPopup | controls whether default Added To Cart Popup is displayed | boolean | true 
 
 ### Content components
 Content components are the building blocks of Tipser Elements. Any components need to be a descendant of **TipserElementsProvider** component. Container components such as **Grid** may contain other components. 

--- a/source/includes/_tipser-widget.md
+++ b/source/includes/_tipser-widget.md
@@ -105,6 +105,26 @@ tipser.elements('myPosId')
 It is possible to combine multiple invocations of `mountContent()` with zero or one invocations of `mountCart()` as presented in the code snippet. That will lead to multiple pieces of content
 AND a cart icon being displayed on the page.
 
+## Advanced example: Custom checkout popup ##
+
+Default Checkout Popup appears upon adding product to the cart. It can be however overridden by fully custom popup via `customCheckoutPopupHandler` configuration parameter. See snippet with an example:  
+
+```js
+tipser.elements('myPosId', {
+    customCheckoutPopupHandler: {
+        init: function (openPurchaseDialog){
+            const checkoutPopup = document.querySelector("#my-custom-checkout-popup");
+            checkoutPopup.querySelector('.checkout-button').addEventListener('click',openPurchaseDialog);
+        },
+        onOpen: function (product){
+            const checkoutPopup = document.querySelector("#my-custom-checkout-popup");
+            checkoutPopup.querySelector('.title').textContent = product.title;
+            checkoutPopup.querySelector('.price').textContent = product.priceIncVat.formatted;
+        }
+    }
+})
+```
+
 ## Specifying a locale ##
 
 ```js
@@ -138,7 +158,9 @@ Parameter | Default | Description | Example
 --------- | ------- | ----------- | -------
 lang | `'en'` | a locale to be used by the Tipser content. Possible values: `en`, `de` and `sv`. | `'de'` 
 env | `prod` | a Tipser environment to be used by the Tipser content. Possible values: `stage` and `prod`. | `'stage'`
-disableDomReplacement | false | Advanced setting. Set to true in case for some reason you don't wish any tag replacement to happen (see: [Replacing elements on your page](#replacing-elements-on-your-page) ). | true
+disableDomReplacement | `false` | Advanced setting. Set to true in case for some reason you don't wish any tag replacement to happen (see: [Replacing elements on your page](#replacing-elements-on-your-page) ). | true
+defaultCheckoutPopup | `true` | Controls default Checkout Popup. It is overrideable by `customCheckputPopupHandler`. Checkout Popup appears when user adds a product to the cart. It improves UX by highlighting the action and allowing to navigate quickly to the cart modal window.  | `true` or `false` 
+customCheckoutPopupHandler | `undefined` | Allows implementation of custom Checkout Popup. If defined, turns off default Checkout Popup | see [Advanced example: custom checkout popup](#advanced-example-custom-checkout-popup)
 
 In addition to the options described above all the configuration options supported by Tipser Elements library are supported.
    

--- a/source/includes/_tipser-widget.md
+++ b/source/includes/_tipser-widget.md
@@ -105,26 +105,6 @@ tipser.elements('myPosId')
 It is possible to combine multiple invocations of `mountContent()` with zero or one invocations of `mountCart()` as presented in the code snippet. That will lead to multiple pieces of content
 AND a cart icon being displayed on the page.
 
-## Advanced example: Custom checkout popup ##
-
-Default Checkout Popup appears upon adding product to the cart. It can be however overridden by fully custom popup via `customCheckoutPopupHandler` configuration parameter. See snippet with an example:  
-
-```js
-tipser.elements('myPosId', {
-    customCheckoutPopupHandler: {
-        init: function (openPurchaseDialog){
-            const checkoutPopup = document.querySelector("#my-custom-checkout-popup");
-            checkoutPopup.querySelector('.checkout-button').addEventListener('click',openPurchaseDialog);
-        },
-        onOpen: function (product){
-            const checkoutPopup = document.querySelector("#my-custom-checkout-popup");
-            checkoutPopup.querySelector('.title').textContent = product.title;
-            checkoutPopup.querySelector('.price').textContent = product.priceIncVat.formatted;
-        }
-    }
-})
-```
-
 ## Specifying a locale ##
 
 ```js
@@ -156,11 +136,10 @@ Tipser Widget supports following configuration options.
 
 Parameter | Default | Description | Example
 --------- | ------- | ----------- | -------
-lang | `'en'` | a locale to be used by the Tipser content. Possible values: `en`, `de` and `sv`. | `'de'` 
-env | `prod` | a Tipser environment to be used by the Tipser content. Possible values: `stage` and `prod`. | `'stage'`
+lang | `'en'` | a locale to be used by the Tipser content. Possible values: `'en'`, `'de'` and `'sv'`. | `'de'` 
+env | `'prod'` | a Tipser environment to be used by the Tipser content. Possible values: `'stage'` and `'prod'`. | `'stage'`
 disableDomReplacement | `false` | Advanced setting. Set to true in case for some reason you don't wish any tag replacement to happen (see: [Replacing elements on your page](#replacing-elements-on-your-page) ). | true
-defaultCheckoutPopup | `true` | Controls default Checkout Popup. It is overrideable by `customCheckputPopupHandler`. Checkout Popup appears when user adds a product to the cart. It improves UX by highlighting the action and allowing to navigate quickly to the cart modal window.  | `true` or `false` 
-customCheckoutPopupHandler | `undefined` | Allows implementation of custom Checkout Popup. If defined, turns off default Checkout Popup | see [Advanced example: custom checkout popup](#advanced-example-custom-checkout-popup)
+defaultCheckoutPopup | `true` | Controls default Checkout Popup. It appears when user adds a product to the cart. It improves UX by highlighting the action and allowing to navigate quickly to the cart modal window.  | `true` or `false` 
 
 In addition to the options described above all the configuration options supported by Tipser Elements library are supported.
    

--- a/source/includes/_tipser-widget.md
+++ b/source/includes/_tipser-widget.md
@@ -139,7 +139,7 @@ Parameter | Default | Description | Example
 lang | `'en'` | a locale to be used by the Tipser content. Possible values: `'en'`, `'de'` and `'sv'`. | `'de'` 
 env | `'prod'` | a Tipser environment to be used by the Tipser content. Possible values: `'stage'` and `'prod'`. | `'stage'`
 disableDomReplacement | `false` | Advanced setting. Set to true in case for some reason you don't wish any tag replacement to happen (see: [Replacing elements on your page](#replacing-elements-on-your-page) ). | true
-defaultCheckoutPopup | `true` | Controls default Checkout Popup. It appears when user adds a product to the cart. It improves UX by highlighting the action and allowing to navigate quickly to the cart modal window.  | `true` or `false` 
+defaultAddedToCartPopup | `true` | Controls default Added To Cart Popup. It appears when user adds a product to the cart. It improves UX by highlighting the action and allowing to navigate quickly to the cart modal window.  | `true` or `false` 
 
 In addition to the options described above all the configuration options supported by Tipser Elements library are supported.
    


### PR DESCRIPTION
Proposition of API of "Added To Cart Popup" handling via Tipser Widget.

see following file for a "complied" markdown: 
https://github.com/Tipser/docs/blob/ad875aacd244fdd3999fd37f8c660d6566e89f43/source/includes/_tipser-widget.md

Same but for Tipser Elements:
https://github.com/Tipser/docs/blob/c59e9c2bdf45b5930427be535b54335725f8e635/source/includes/_tipser-elements.md