### PR TITLE
docs for new tipser elements analytics

### DIFF
--- a/source/includes/_google-analytics.md
+++ b/source/includes/_google-analytics.md
@@ -1,6 +1,6 @@
-#Tipser Elements Analytics
+#Google Analytics
 
-Tipser Elements library sends a number of analytics events to Google Analytics as a result of user actions.
+Tipser sends a number of analytics events to Google Analytics as a result of user actions.
 
 ### GA account configuration ###
 
@@ -33,77 +33,6 @@ Some of the events emitted by Tipser Elements are standard Enhanced Ecommerce ev
 
 Please refer to [Enhanced Ecommerce Data Types and Actions](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#ecommerce-data) and 
  [Measuring Ecommerce Activities](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#measuring-activities) sections in the official GA docs.
-
-## Shop view
-
-This event is emitted every time `Store` is rendered on a page.
-
-[![](shop_viewed.png)](/images/shop_viewed.png)
-
-_In the screenshot above Store was rendered and "Shop view" event has been emitted._
-
-### Prerequisites ###
- 
-An element of type `Layout - Container` needs to be defined in Contentful space. 
-The field `IsShop` on that element needs to be set to `true`. 
-
-### Additonal notes ###
-
-The event is emitted no matter if the shop element is actually visible on the screen.
-It is possible that if the shop element is positioned below the fold of the browser window, the event
-will be emitted for the shop that was not seen by the user.
-
-### GA event format ###
-
-Category    | Action        | Standard Enhanced Ecommerce event?
----------   | -----------   | -----------
-`Shops`     | `shop-viewed` | No
-
-
-## Shop list clicked
-
-This event is emitted every time a list in a Store is clicked.
-
-[![](shop_list_clicked.png)](/images/shop_viewed.png)
-
-_In the screenshot above one of the Store lists was clicked (marked with a red rectangle) and "Shop list clicked" event has been emitted._
-
-### Prerequisites ###
-
-Store categories need to be defined as `Slottable Link` components (typically as a part of horizontal menu component) in Contentful space. In component hierarchy they need
- to be located anywhere under `Layout - Container` component whose field `IsShop` is set to `true` (otherwise they won't be recognized as a part of the Store).
-
-### GA event format ###
-
-Category    | Action         | Standard Enhanced Ecommerce event?
----------   | -----------    | -----------
-`Shops`     | `list-clicked` | No
-
-
-## Product tile view
-
-This event is emitted every time product tile is rendered on a page. One event is fired per every tile on the page.
-
-[![](inline_product_viewed.png)](/images/inline_product_viewed.png)
-
-_In the screenshot above some product tiles were rendered on a page and "Shop list clicked" event has been emitted for each of them._
-
-### Prerequisites ###
-
-Products need to be defined as `Product` components in Contentful space.
-
-### Additonal notes ###
-
-The event is emitted no matter if the Product tile element is actually visible on the screen.
-It is possible that if the product tile element is positioned below the fold of the browser window, the event
-will be emitted for the product tile that was not seen by the user.
-
-
-### GA event format ###
-
-Category         | Action       | Standard Enhanced Ecommerce event?
----------        | -----------  | -----------
-`E-commerce`     | `impression` | Yes (with one product attached)
 
 ## Product details view
 

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -77,8 +77,8 @@ When a product in a collection is clicked.
 ```
 _Quick links to object structures: [Product](#product-structure)_
 
-### View product
-When a product in a collection is viewed.
+### View product details
+It is emitted every time product tile is clicked and product dialog is displayed.
 
 `detail` object structure
 

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -41,7 +41,7 @@ document.addEventListener('tw-track', function (e) {
 ## List of supported interactions
 
 ### View collection
-When a collection is in a viewport.
+When a collection appears in the viewport.
 
 `detail` object structure
 
@@ -93,7 +93,7 @@ It is emitted every time product tile is clicked and product dialog is displayed
 _Quick links to object structures: [Product](#product-structure)_
 
 ### View the Store
-When the Tipser store is viewed.
+When the Tipser store appears in the viewport.
 
 `detail` object structure
 
@@ -158,7 +158,7 @@ When a product is added to a shopping cart.
 _Quick links to object structures: [ProductLegacy](#productlegacy-structure)_
 
 ### View cart - with purchase intent
-When viewing the cart, and getting payment in view.
+When cart appears in the viewport, and getting payment in view.
 
 `detail` object structure
 
@@ -174,7 +174,7 @@ When viewing the cart, and getting payment in view.
 _Quick links to object structures: [OrderedProductLegacy](#orderedproductlegacy-structure)_
 
 ### Product purchased
-When a product was bought (thank you page)
+When a product was bought (thank you page).
 
 
 `detail` object structure
@@ -195,8 +195,8 @@ When a product was bought (thank you page)
 _Quick links to object structures: [ProductLegacy](#productlegacy-structure)_
 
 
-### View cart (not implemented)
-When cart icon is in the viewport 
+### View cart
+When cart icon appears in the viewport.
 
 `detail` object structure
 

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -92,8 +92,8 @@ It is emitted every time product tile is clicked and product dialog is displayed
 ```
 _Quick links to object structures: [Product](#product-structure)_
 
-### View the shop
-When the Tipser shop is viewed.
+### View the Store
+When the Tipser store is viewed.
 
 `detail` object structure
 
@@ -104,7 +104,7 @@ When the Tipser shop is viewed.
   target: 'Shop',
   object: [
     { 
-      url_slug: string # shop url slug 
+      url_slug: string # store url slug 
     }
   ]
 }

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -1,0 +1,308 @@
+# Tipser Elements Analytics
+
+Tipser has implemented an event for the Tipser Elements Analytics that users of the script can listen to in order to gather analytics about Tipser interactions and feed them into their own analytics engines.
+
+## General overview of the Tipser Elements Analytics collector
+By listening to the event `tw-track` certain Tipser events can be gathered and pushed into an external analytics engine.
+
+The event contains the object detail that contains the following items:
+
+`detail` object
+
+```yaml
+{
+  action: string, # what action is taken on the target, mandatory
+  target: string, # where this action is taken, mandatory
+  description: string, # describing what is being logged
+  object: # details about the tracked object, e.g. collection ID, product ID, etc.
+  [    
+    {  
+      # some properties here               
+    },     
+    ..., # this array can contain more than 1 object
+  ]
+}
+```
+
+
+Example of an event listener:
+
+```javascript
+document.addEventListener('tw-track', function (e) {
+  var detial = e.detail; 
+  console.log('tw-track');
+  console.log('tw-track action',detial.action);
+  console.log('tw-track description',detial.description);
+  console.log('tw-track target',detial.target);
+  console.log('tw-track object',detial.object);
+});
+```
+
+## List of supported events
+
+### View collection
+When a collection is in a viewport.
+
+`detail` object structure
+
+ ```yaml
+{
+  description: ‘Viewport scrolled’,
+  action: 'View',
+  target: 'List',
+  object:  {
+    id: string,
+    ownerUserId: string,
+    created: string, #e.g. DateTime ISO 2019-06-11T08:40:29.377Z
+    modified: string, #e.g. DateTime ISO 2019-06-11T08:40:29.377Z
+    postComment: null | ?
+    product: Product     
+  }[]
+}
+```  
+_Quick links to object structures: [Product](#product-structure)_ 
+
+### Click product in collection
+When a product in a collection is clicked.
+
+`detail` object structure
+
+```yaml
+{
+  description: 'Product tile clicked',
+  action: 'Click',
+  target: 'Product tile',
+  object: Product[]
+}
+```
+_Quick links to object structures: [Product](#product-structure)_
+
+### View product
+When a product in a collection is viewed.
+
+`detail` object structure
+
+```yaml
+{
+  description: 'Product detail page viewed',
+  action: 'View',
+  target: 'Product',
+  object: Product[] # Product which interests us is the first element of an Array 
+}
+```
+_Quick links to object structures: [Product](#product-structure)_
+
+### View the shop
+When the Tipser shop is viewed.
+
+`detail` object structure
+
+```yaml
+{
+  description: 'Shop viewed',
+  action: 'View',
+  target: 'Shop',
+  object: [
+    { 
+      url_slug: string # shop url slug 
+    }
+  ]
+}
+```
+
+### Click menu item in shop
+When a menu item is clicked in the shop.
+
+`detail` object structure
+
+```yaml
+{ 
+  description: 'List clicked',
+  action: 'Click,
+  target: 'List',
+  object:[
+    { 
+      id: string, # collection id
+    } 
+  ]
+```
+
+### Click cart tab
+When the shopping cart tab is clicked.
+
+`detail` object structure
+
+```yaml
+{
+  description: 'Cart clicked',
+  action: 'Click',
+  target: 'Cart-tab',
+  object: []
+}
+```
+
+### Add product to cart
+  
+When a product is added to a shopping cart.
+
+`detail` object structure
+
+```yaml
+{
+  description: ‘Product added to cart’,
+  action: 'Cart',
+  target: 'Product',
+  object: ProductLegacy[]
+}
+```
+_Quick links to object structures: [ProductLegacy](#productlegacy-structure)_
+
+### View cart - with purchase intent
+When viewing the cart, and getting payment in view.
+
+`detail` object structure
+
+```yaml
+{
+  description: 'View cart - payment in viewport',
+  action: 'View',
+  target: 'Payment',
+  object: OrderedProductLegacy[]
+}
+```
+
+_Quick links to object structures: [OrderedProductLegacy](#orderedproductlegacy-structure)_
+
+### Product purchased
+When a product was bought (thank you page)
+
+
+`detail` object structure
+
+```yaml
+{
+  description: ‘Product purchased’,
+  action: 'Purchase',
+  target: 'Order',
+  object: [
+    {
+      OrderId: string, 
+      Products: ProductLegacy[]
+    }
+  ]
+}
+```
+_Quick links to object structures: [ProductLegacy](#productlegacy-structure)_
+
+
+### View cart (not implemented)
+When cart icon is in the viewport 
+
+`detail` object structure
+
+```yaml
+{
+  description: ‘View cart’,
+  action: 'View',
+  target: 'Cart',
+  object: []
+}
+```
+
+## Objects structures
+
+### `ProductLegacy` structure
+```yaml
+{ # Representation of product, but slightly different schema than Product
+  id: string,
+  name: string,
+  brand: string,
+  campaign: undefined,
+  categories: CategoriesLegacy
+  image: string, # url
+  listPrice: Price,
+  salesPrice: Price,
+  variant: [],
+  merchant: undefined
+}
+```
+_Quick links to object structures: [CategoriesLegacy](#categorieslegacy-structure), [Price](#price-structure)_
+
+### `OrderedProductLegacy` structure
+```yaml
+{ # Representation of product, but slightly different schema than Product
+  id: string,
+  name: string,
+  brand: string,
+  campaign: undefined,
+  categories: CategoriesLegacy 
+  merchant: string
+  image: string, # url
+  listPrice: Price,
+  salesPrice: Price,
+  variant: [],
+  posId: string,
+  quantity: number
+}
+```
+_Quick links to object structures: [CategoriesLegacy](#categorieslegacy-structure), [Price](#price-structure)_
+
+### `CategoriesLegacy` structure
+
+```yaml
+{
+  [key]: string
+}[]
+```
+
+### `Product` structure
+
+```yaml
+{
+  id: string,
+  title: string,
+  images: Image[],
+  brand: string,
+  catgories: Categories
+  currency: string, #ISO 4217
+  description: string,
+  priceInVat: Price,
+  isInStock: boolean,
+  variants: [],
+  vat: { # percentage of VAT
+    value: number,
+    formatted: string, # human readable value percentage string
+  }      
+  categoriesValue: string
+}
+```
+_Quick links to object structures: [Categories](#categories-structure), [Price](#price-structure), [Image](#image-structure)_
+
+### `Image` structure
+
+```yaml
+{
+  [key]: string 
+  id: string,
+  original: string
+}
+```
+Each value is url for the certain variation of an image. `key` determines size, and it is one of following: `250x`, `450x`, `960x`, `50x50`.
+
+### `Categories` structure
+
+```yaml
+  department: string,
+  section: string,
+  productType: string
+``` 
+
+### `Price` structure
+
+```yaml
+{
+  value: number,
+  currency: string, #ISO 4217
+  formatted: string, # human readable price string    
+}
+```

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -1,6 +1,6 @@
 # Tipser Elements Analytics
 
-Tipser has implemented an event for the Tipser Elements Analytics that users of the script can listen to in order to gather analytics about Tipser interactions and feed them into their own analytics engines.
+Tipser has implemented an event for the Tipser Elements Analytics that users of the script can listen to in order to gather analytics about Tipser interactions and feed them into their own analytics engines.  
 
 ## General overview of the Tipser Elements Analytics collector
 By listening to the event `tw-track` certain Tipser events can be gathered and pushed into an external analytics engine.
@@ -38,7 +38,7 @@ document.addEventListener('tw-track', function (e) {
 });
 ```
 
-## List of supported events
+## List of supported interactions
 
 ### View collection
 When a collection is in a viewport.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -14,6 +14,7 @@ includes:
   - tipser-sdk.md
   - configuration-options.md
   - amp.md
+  - tipser-elements-analytics.md
   - google-analytics.md
   - rest-api.md
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -14,7 +14,7 @@ includes:
   - tipser-sdk.md
   - configuration-options.md
   - amp.md
-  - tipser-elements-analytics.md
+  - google-analytics.md
   - rest-api.md
 
 


### PR DESCRIPTION
Providing up to date documentation about tracking Tipser events. Tipser custom analytics events.

**What was done?**
- Tracking events were already implemented by @mateuszsikora 
- previous Analytics section is moved to "Google Analytics"
- new section is called now "Tipser Elements Analytics"
- new section is created based on previous documentation https://developers.tipser.com/tipser-analytics and slightly updated, what makes it - I hope - more readable
- two events were removed:
  - events:
    - "View tagged image"
    - "Click image tag"
  - as @zdanowiczkonrad said tagged image are no longer supported 
   

**What still needs to be done? Bugs!**
- when frontend-ui code is in iframe, events are not propagated to root window
  - https://tipser.atlassian.net/browse/T3-3535
- Wrongly implemented structure of `detail` object for "Click product in collection" https://tipser.atlassian.net/browse/T3-3532
- Investigate "View cart" event
  - in tipser-elements it is triggered once Cart Icon is in viewport
  - in `frontend-ui` it is implemented - but in dead code zone - when cart icon is clicked and cart popup is open https://github.com/Tipser/frontend-ui/blob/5fa9904a495bfd989422640e2fe632ade40d4057/web/src/views/shopping-cart/shopping-cart-panel.tsx#L97-L100
  - I have not added a task for it so let me know what you think ?

**GIF**
![Screen Recording 2019-09-09 at 15 17 56](https://user-images.githubusercontent.com/3996881/64534098-1618aa80-d315-11e9-8d08-52d84ea0bd97.gif)

