### PR TITLE
fix link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/source/includes/_tipser-react-elements.md
+++ b/source/includes/_tipser-react-elements.md
@@ -15,7 +15,7 @@ The code of that page is available as a GitHub [Tipser Elements Bootstrap projec
 
 ***
 
-## Quick Start
+## Quick React Start
 This quick guide explains how to intialize and render Tipser React Elements on your React app. It requires you to have a publisher account created in order to get the `posId`, as well as have some collections created in your shop. For a guide how to manage your collections, check the **Tipser Tools** tutorial.
 
 If you're all set up, follow this three steps to rock on your app with Tipser React Elements!


### PR DESCRIPTION
-fixing Quick Start link in 'Tipser React Elements' and change its name to 'Quick React Start'.
![Screenshot (16)](https://user-images.githubusercontent.com/40540225/70044963-97ee3c00-15c3-11ea-8c24-e084a9c766e5.png)
