### PR TITLE
[T3-4186] Add facebook pixel integration instruction

### DIFF
--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -90,7 +90,7 @@ document.addEventListener('tw-track', function(e) {
 ```
 Example above doesn't translate tipser events to pixel events, you will have to make corelation in pixel dashboard or you can use function that translates those for you. 
 
-1. Go <a href="https://gist.github.com/sirpeas/b434ca8972228f0b453a82a57558325a" target="_blank">here</a> and copy the script.
+1. Go <a href="https://gist.github.com/sirpeas/1aadb088dc2c81687036354e2549c3cd" target="_blank">here</a> and copy the script.
 2. Paste it above addEventListener for tw-track event.
 3. Use it like on belowed example
 

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -60,7 +60,7 @@ In case you want to tunnel Tipser Analytics events to your Google Analytics, you
 
 ```javascript
 document.addEventListener('tw-track', function(e) {
-    //ga() function coming from analytics.js library
+    // ga() function coming from analytics.js library
     ga('send', {
         hitType: 'event',
         eventCategory: e.detail.description,
@@ -73,6 +73,25 @@ document.addEventListener('tw-track', function(e) {
 The code above assumes that you use <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs" target="_blank">analytics.js</a> GA client library on your page. For other libraries, like gtag.js, that code needs to be slightly adjusted.
 
 For the instructions how to setup analytics.js script on your site and connect it to your GA account, refer to the <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs" target="_blank">official documentation</a>.
+
+## Typical use case: Facebook Pixel
+
+Facebook Pixel is also an option to tunnel Tipser Analytics events, here's a snippet:
+
+```javascript
+document.addEventListener('tw-track', function(e) {
+    // fbq() function coming from Facebook Pixel analytics script
+    fbq('trackCustom', e.detail.action, {
+        content_name: e.detail.target, 
+        content_category: e.detail.description,
+        content_type: e.detail.action,
+    });
+});
+```
+
+The code above assumes that you use <a href="https://developers.facebook.com/docs/facebook-pixel/implementation" target="_blank">pixel.js</a> facebook client library on your page.
+
+For the instructions how to setup pixel.js script on your site and connect it to your Facebook for Developers account, refer to the <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs" target="_blank">official documentation</a>.
 
 ## List of supported interactions
 

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -90,7 +90,7 @@ document.addEventListener('tw-track', function(e) {
 ```
 Example above doesn't translate tipser events to pixel events, you will have to make corelation in pixel dashboard or you can use function that translates those for you. 
 
-1. Go <a href="https://gist.github.com/sirpeas/1aadb088dc2c81687036354e2549c3cd" target="_blank">here</a> and copy the script.
+1. Go <a href="https://gist.github.com/sirpeas/114bba643e920b0f53dff9487670f509" target="_blank">here</a> and copy the script.
 2. Paste it above addEventListener for tw-track event.
 3. Use it like on belowed example
 

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -90,7 +90,7 @@ document.addEventListener('tw-track', function(e) {
 ```
 Example above doesn't translate tipser events to pixel events, you will have to make corelation in pixel dashboard or you can use function that translates those for you. 
 
-1. Go <a href="https://gist.github.com/sirpeas/b434ca8972228f0b453a82a57558325a">here</a> and copy script.
+1. Go <a href="https://gist.github.com/sirpeas/b434ca8972228f0b453a82a57558325a" target="_blank">here</a> and copy the script.
 2. Paste it above addEventListener for tw-track event.
 3. Use it like on belowed example
 

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -88,6 +88,15 @@ document.addEventListener('tw-track', function(e) {
     });
 });
 ```
+Example above doesn't translate tipser events to pixel events, you will have to make corelation in pixel dashboard or you can use function that translates those for you. 
+
+1. Go <a href="https://gist.github.com/sirpeas/b434ca8972228f0b453a82a57558325a">here</a> and copy script.
+2. Paste it above addEventListener for tw-track event.
+3. Use it like on belowed example
+
+```javascript
+document.addEventListener('tw-track', callPixelEvent);
+```
 
 The code above assumes that you use <a href="https://developers.facebook.com/docs/facebook-pixel/implementation" target="_blank">pixel.js</a> facebook client library on your page.
 

--- a/source/includes/_tipser-elements-analytics.md
+++ b/source/includes/_tipser-elements-analytics.md
@@ -56,7 +56,7 @@ As you can see, all the useful data is contained in the top-level `detail` field
 
 ## Typical use case: Google Analytics
 
-In case you want to tunnel Tipser Analytics events to your Google Analytics, you can use this code snippet:
+In case you want to forward Tipser Analytics events to your Google Analytics, you can use this code snippet:
 
 ```javascript
 document.addEventListener('tw-track', function(e) {
@@ -76,7 +76,7 @@ For the instructions how to setup analytics.js script on your site and connect i
 
 ## Typical use case: Facebook Pixel
 
-Facebook Pixel is also an option to tunnel Tipser Analytics events, here's a snippet:
+In case you want to forward Tipser Analytics events to your Facebook Pixel account, you can use the following code snippet:
 
 ```javascript
 document.addEventListener('tw-track', function(e) {
@@ -88,11 +88,11 @@ document.addEventListener('tw-track', function(e) {
     });
 });
 ```
-Example above doesn't translate tipser events to pixel events, you will have to make corelation in pixel dashboard or you can use function that translates those for you. 
+The example above doesn't translate Tipser events to standard Pixel events, you will have to make a correlation in the Pixel dashboard or you can write a custom mapping function. 
 
 1. Go <a href="https://gist.github.com/sirpeas/114bba643e920b0f53dff9487670f509" target="_blank">here</a> and copy the script.
-2. Paste it above addEventListener for tw-track event.
-3. Use it like on belowed example
+2. Paste it above `addEventListener` for tw-track event.
+3. Use it the same way as in the example below
 
 ```javascript
 document.addEventListener('tw-track', callPixelEvent);


### PR DESCRIPTION
# What?
Added instruction on how to integrate Tipser Analytics with Facebook Pixel

# Screens
<img width="909" alt="Screenshot 2020-02-11 at 14 23 07" src="https://user-images.githubusercontent.com/4818642/74240387-2bd23780-4cda-11ea-8fc9-334a329c63e1.png">
<img width="883" alt="Screenshot 2020-02-11 at 14 24 00" src="https://user-images.githubusercontent.com/4818642/74240389-2d9bfb00-4cda-11ea-874c-ebec21411346.png">
