### PR TITLE
[feature] adjust changelog compiler to work with many changelog files

### DIFF
--- a/changelog/scripts/generate_changelog_html.sh
+++ b/changelog/scripts/generate_changelog_html.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mkdir -p build
 cp -R changelog/resources/* build
-cat changelog/tipser-elements/CHANGELOG.md | node changelog/scripts/changelog-compiler.js > build/changelog.html
+node changelog/scripts/changelog-compiler.js > build/changelog.html


### PR DESCRIPTION
I've change our changelog compiler to handle more than one changelog file. it is needed to combine tipser-elements changelogs from two branches